### PR TITLE
Remove frameworks/base wildcard

### DIFF
--- a/app/src/main/Android.mk
+++ b/app/src/main/Android.mk
@@ -39,11 +39,7 @@ LOCAL_PACKAGE_NAME := MatLog
 LOCAL_MODULE_TAGS := optional
 LOCAL_PRIVILEGED_MODULE := true
 
-ifneq (,$(wildcard frameworks/base))
-  LOCAL_SDK_VERSION := current
-else
-  LOCAL_SDK_VERSION := system_current
-endif
+LOCAL_SDK_VERSION := system_current
 
 include $(BUILD_PACKAGE)
 


### PR DESCRIPTION
Fixes: Specifies both LOCAL_SDK_VERSION (system_current) and
LOCAL_PRIVATE_PLATFORM_APIS (true) but should specify only one.