### PR TITLE
Move to system_ext partition

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -36,7 +36,7 @@ android_app {
 
     platform_apis: true,
     privileged: true,
-    product_specific: true,
+    system_ext_specific: true,
 
     required: [
         "privapp_whitelist_org.omnirom.logcat"
@@ -45,7 +45,7 @@ android_app {
 
 prebuilt_etc {
     name: "privapp_whitelist_org.omnirom.logcat",
-    product_specific: true,
+    system_ext_specific: true,
     sub_dir: "permissions",
     src: "app/src/main/privapp_whitelist_org.omnirom.logcat.xml",
     filename_from_src: true,


### PR DESCRIPTION
* Fix build error on dynamic partition devices

Fixes:
error: packages/apps/Matlog/Android.bp:17:1: module "MatLog" variant "android_common": sdk_version: sdk_version must have a value when the module is located at vendor or product(only if PRODUCT_ENFORC E_PRODUCT_PARTITION_INTERFACE is set).

Signed-off-by: Jabiyeff <cebiyevanar@gmail.com>